### PR TITLE
Tic Tac Toe: Fixes win check on the last turn

### DIFF
--- a/tictactoe/board.go
+++ b/tictactoe/board.go
@@ -42,17 +42,18 @@ func (b *board) result() uint8 {
 func (b *board) newClick(row, column int) {
 	b.pieces[row][column] = b.turn%2 + 1
 
-	if b.turn > 3 && b.turn < 8 {
+	if b.turn > 3 {
 		winner := b.result()
 		if winner == 0 {
+			if b.turn == 8 {
+				dialog.ShowInformation("It is a tie!", "Nobody has won. Better luck next time.", fyne.CurrentApp().Driver().AllWindows()[0])
+				b.finished = true
+			}
 			return
 		}
 
 		number := string(winner + 48) // Number 1 is ascii #49 and 2 is ascii #50.
 		dialog.ShowInformation("Player "+number+" has won!", "Congratulations to player "+number+" for winning.", fyne.CurrentApp().Driver().AllWindows()[0])
-		b.finished = true
-	} else if b.turn == 8 {
-		dialog.ShowInformation("It is a tie!", "Nobody has won. Better luck next time.", fyne.CurrentApp().Driver().AllWindows()[0])
 		b.finished = true
 	}
 }


### PR DESCRIPTION
The fix adds a winning conditions check for the last turn.

My first attempt to test/play the game happened to end in a win on the last turn, however the app showed "It is a tie!".

In this commit, I removed the upper bound check (as the turn can not be bigger than 8, and we need to check a win in case it is 8), and moved the code to show "It is a tie!" to be displayed only if there is no winner and the turn is 8. After turn 8, b.finished will be true (if there is no winner, it will become true because it is turn 8; otherwise we have a winner, and b.finished will become true too).